### PR TITLE
CC-26539: Adjusted the state machine file validation.

### DIFF
--- a/src/Spryker/Zed/StateMachine/Business/StateMachine/Builder.php
+++ b/src/Spryker/Zed/StateMachine/Business/StateMachine/Builder.php
@@ -270,11 +270,11 @@ class Builder implements BuilderInterface
     {
         $pathToXml = $pathToXml . DIRECTORY_SEPARATOR . $fileName . '.xml';
 
-        if (!file_exists($pathToXml)) {
+        if (!$this->isValidPath($pathToXml)) {
             throw new StateMachineException(
                 sprintf(
                     'State machine XML file not found in "%s".',
-                    $pathToXml,
+                    str_replace(APPLICATION_ROOT_DIR, '', $this->stateMachineConfig->getPathToStateMachineXmlFiles()),
                 ),
             );
         }
@@ -290,6 +290,19 @@ class Builder implements BuilderInterface
         }
 
         return $this->loadXml($xmlContents);
+    }
+
+    /**
+     * @param string $pathToXml
+     *
+     * @return bool
+     */
+    protected function isValidPath(string $pathToXml): bool
+    {
+        $realPathToXml = realpath($pathToXml);
+        $realPathToStateMachineXmlFiles = realpath($this->stateMachineConfig->getPathToStateMachineXmlFiles());
+
+        return $realPathToXml && strpos($realPathToXml, $realPathToStateMachineXmlFiles . '/') === 0;
     }
 
     /**

--- a/src/Spryker/Zed/StateMachine/Business/StateMachine/Builder.php
+++ b/src/Spryker/Zed/StateMachine/Business/StateMachine/Builder.php
@@ -269,8 +269,10 @@ class Builder implements BuilderInterface
     protected function loadXmlFromFileName($pathToXml, $fileName)
     {
         $pathToXml = $pathToXml . DIRECTORY_SEPARATOR . $fileName . '.xml';
+        $realPathToXml = realpath($pathToXml);
+        $realPathToStateMachineXmlFiles = realpath($this->stateMachineConfig->getPathToStateMachineXmlFiles());
 
-        if (!$this->isValidPath($pathToXml)) {
+        if (!$realPathToXml || strpos($realPathToXml, $realPathToStateMachineXmlFiles . '/') !== 0) {
             throw new StateMachineException(
                 sprintf(
                     'State machine XML file not found in "%s".',
@@ -290,19 +292,6 @@ class Builder implements BuilderInterface
         }
 
         return $this->loadXml($xmlContents);
-    }
-
-    /**
-     * @param string $pathToXml
-     *
-     * @return bool
-     */
-    protected function isValidPath(string $pathToXml): bool
-    {
-        $realPathToXml = realpath($pathToXml);
-        $realPathToStateMachineXmlFiles = realpath($this->stateMachineConfig->getPathToStateMachineXmlFiles());
-
-        return $realPathToXml && strpos($realPathToXml, $realPathToStateMachineXmlFiles . '/') === 0;
     }
 
     /**


### PR DESCRIPTION
- Developer(s): @sakharova-yuliia 

- Ticket: https://spryker.atlassian.net/browse/CC-26539

- Release Group: https://release.spryker.com/release-groups/view/4905

- PR Overview: https://release.spryker.com/release/pull-request/10305

- merge: squash

- Strategy: minor

- Version: 2.15.2

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   StateMachine              | patch                 |                       |

-----------------------------------------

#### Module StateMachine

##### Change log

Fixes

-  Adjusted the following facade methods `StateMachineFacade::checkConditions()`, `StateMachineFacade::getManualEventsForStateMachineItem()`, `StateMachineFacade::getProcessStateNames()`, `StateMachineFacade::getItemsWithoutFlag()`, `StateMachineFacade::triggerEvent()` and `StateMachineFacade::triggerEventForItems()` to throws an exception when the path to the state machine file is not valid.
 - Impacted with facade changes the following controller actions `GraphController::drawAction()`, `GraphController::drawItemAction()`, `TriggerController::submitTriggerEventAction()` and `TriggerController::triggerEventAction()`.
 - Impacted `CheckConditionConsole` with facade changes.