### PR TITLE
CC-26539: Adjusted the state machine file validation.

### DIFF
--- a/src/Spryker/Zed/StateMachine/Business/StateMachine/Builder.php
+++ b/src/Spryker/Zed/StateMachine/Business/StateMachine/Builder.php
@@ -236,7 +236,7 @@ class Builder implements BuilderInterface
             throw new StateMachineException(
                 sprintf(
                     'State machine XML file not found in "%s".',
-                    str_replace(APPLICATION_ROOT_DIR, '', $this->stateMachineConfig->getPathToStateMachineXmlFiles())
+                    str_replace(APPLICATION_ROOT_DIR, '', $this->stateMachineConfig->getPathToStateMachineXmlFiles()),
                 )
             );
         }

--- a/src/Spryker/Zed/StateMachine/Business/StateMachine/Builder.php
+++ b/src/Spryker/Zed/StateMachine/Business/StateMachine/Builder.php
@@ -229,12 +229,14 @@ class Builder implements BuilderInterface
     protected function loadXmlFromFileName($pathToXml, $fileName)
     {
         $pathToXml = $pathToXml . DIRECTORY_SEPARATOR . $fileName . '.xml';
+        $realPathToXml = realpath($pathToXml);
+        $realPathToStateMachineXmlFiles = realpath($this->stateMachineConfig->getPathToStateMachineXmlFiles());
 
-        if (!file_exists($pathToXml)) {
+        if (!$realPathToXml || strpos($realPathToXml, $realPathToStateMachineXmlFiles . '/') !== 0) {
             throw new StateMachineException(
                 sprintf(
                     'State machine XML file not found in "%s".',
-                    $pathToXml
+                    str_replace(APPLICATION_ROOT_DIR, '', $this->stateMachineConfig->getPathToStateMachineXmlFiles())
                 )
             );
         }


### PR DESCRIPTION
- Developer(s): @sakharova-yuliia 

- Ticket: https://spryker.atlassian.net/browse/CC-26539

- Release Group: https://release.spryker.com/release-groups/view/4905

- PR Overview: https://release.spryker.com/release/pull-request/10305

- merge: squash

- Strategy: minor

- Version: 2.14.1

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   StateMachine              | patch                 |                       |

-----------------------------------------

#### Module StateMachine

##### Change log

Fixes

-  Adjusted the following facade methods `StateMachineFacade::checkConditions()`, `StateMachineFacade::getManualEventsForStateMachineItem()`, `StateMachineFacade::getProcessStateNames()`, `StateMachineFacade::getItemsWithoutFlag()`, `StateMachineFacade::triggerEvent()` and `StateMachineFacade::triggerEventForItems()` to throws an exception when the path to the state machine file is not valid.
 - Impacted with facade changes the following controller actions `GraphController::drawAction()`, `GraphController::drawItemAction()`, `TriggerController::submitTriggerEventAction()` and `TriggerController::triggerEventAction()`.
 - Impacted `CheckConditionConsole` with facade changes.